### PR TITLE
Fix bug in upload where remote files aren't cleared

### DIFF
--- a/script/main.go
+++ b/script/main.go
@@ -147,10 +147,10 @@ func upload() error {
 	}
 
 	// clear bin/website-old/ directory in preparation for storing old website
-	// if err := os.RemoveAll(SITE_OLD_DIRECTORY); err != nil {
-	// 	fmt.Println("Error: cannot clear '" + SITE_OLD_DIRECTORY + "' directory")
-	// 	return err
-	// }
+	if err := os.RemoveAll(SITE_OLD_DIRECTORY); err != nil {
+		fmt.Println("Error: cannot clear '" + SITE_OLD_DIRECTORY + "' directory")
+		return err
+	}
 
 	if len(files) <= 0 {
 		fmt.Println("    Nothing to download")
@@ -165,7 +165,9 @@ func upload() error {
 	}
 
 	fmt.Println("Removing old website from webhost")
-	// runRemoteCommandToConsole(client, "rm -rf "+websiteRoot+"/*") // delete everything in the website directory
+	if _, err := runRemoteCommand(client, "rm -rf "+websiteRoot+"/*"); err != nil { // delete everything in the website directory
+		return err
+	}
 
 	fmt.Println("Uploading new website to webhost")
 	if err := filepath.WalkDir(HUGO_BUILD_DIRECTORY, func(path string, file fs.DirEntry, walkErr error) error {


### PR DESCRIPTION
There was a bug in the upload command of the ./website tool where remote files weren't cleared out prior to the new website being deleted. Hence old parts of the website would still stick around.

This was fixed by uncommenting the code I had to delete these files, as well as deleting the code that cleared the backup bin/old-website directory (to ensure that the old-website didn't get mingled with even older versions).