### PR TITLE
Keep public/ and bin/ folders when clearing, just delete child folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ website : script/main.go
 # clear out ./website binary, public/ (hugo output), and bin/ (other output)
 clean :
 	-rm website
-	-rm -rf public
-	-rm -rf bin
+	-rm -rf public/*
+	-rm -rf bin/*


### PR DESCRIPTION
I found that when running certain build/deploy commands, deleting the public/ and bin/ folders before (eg. to ensure a clean build) sometimes causes issues. To minimize this risk, instead just delete all of their children and keep the folders themselves.