### PR TITLE
Add .htaccess file for 404 redirect

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,2 @@
+# default 404 page is 404.shtml - we change it to 404.html
+FallbackResource /404.html


### PR DESCRIPTION
The apache webserver I'm currently using (hosted on GoDaddy) uses 404.shtml for its redirect. This adds a .htaccess file to my website with a `404` redirect to 404.html (which is the 404 file hugo uses) so that I can have my website use the right 404 file.