### PR TITLE
Much more efficient method for listing remote files

### DIFF
--- a/script/main.go
+++ b/script/main.go
@@ -430,7 +430,7 @@ func downloadRemoteFile(client *ssh.Client, remoteFileLocation, destinationFileN
 // the remote directory specified by [remoteDirectoryPath]. Includes
 // recursive files, ie. listing remote files in /foo will list /foo/bar/baz.txt
 func listRemoteFiles(client *ssh.Client, remoteDirectoryPath string) ([]string, error) {
-	buffer, err := runRemoteCommand(client, "ls -A "+remoteDirectoryPath)
+	buffer, err := runRemoteCommand(client, "find "+remoteDirectoryPath+" -type f")
 	if err != nil {
 		return nil, err
 	}
@@ -448,28 +448,7 @@ func listRemoteFiles(client *ssh.Client, remoteDirectoryPath string) ([]string, 
 		if len(trimmedFile) <= 0 {
 			continue
 		}
-		fullFileName := remoteDirectoryPath + "/" + trimmedFile
-
-		isFile, err := remoteFileIsFile(client, fullFileName)
-		if err != nil {
-			return nil, err
-		}
-
-		isDirectory, err := remoteFileIsDirectory(client, fullFileName)
-		if err != nil {
-			return nil, err
-		}
-
-		if isFile {
-			filesToReturn = append(filesToReturn, fullFileName)
-		}
-		if isDirectory {
-			recursiveFiles, err := listRemoteFiles(client, fullFileName)
-			if err != nil {
-				return nil, err
-			}
-			filesToReturn = append(filesToReturn, recursiveFiles...)
-		}
+		filesToReturn = append(filesToReturn, trimmedFile)
 	}
 
 	return filesToReturn, nil


### PR DESCRIPTION
Before uploading the website, I list all of the files on the remote and download them (in case I need to rollback). Currently I use `ls -A`, testing each file with `test -d` and `test -f` to see if it was a file or directory, and then repeating the process recursively for each directory. That means that if there are N files+directories, I run 3N remote commands 😱 

This change instead uses `find <location> -type f`, which achieves the same thing in 1 command (O(N) vs. O(1) - pretty good!)